### PR TITLE
[API-864] Add mongodb ObjectId support to arrow-orm

### DIFF
--- a/lib/instance.js
+++ b/lib/instance.js
@@ -6,7 +6,8 @@ var util = require('util'),
 	error = require('./error'),
 	ORMError = error.ORMError,
 	ValidationError = error.ValidationError,
-	_ = require('lodash');
+	_ = require('lodash'),
+	ObjectID = require('mongodb').ObjectID;
 
 util.inherits(Instance, events.EventEmitter);
 module.exports = Instance;
@@ -177,6 +178,14 @@ Instance.prototype.validateCoersiveTypes = function validateCoersiveTypes(field,
 				return true;
 			}
 			break;
+		}
+		case 'mongo.oid': {
+			if(value instanceof ObjectID) {
+				return true;
+			} else if(typeof(value)==='string') {
+				this.set(name, new ObjectID(value));
+				return true;
+			}
 		}
 	}
 	return false;
@@ -406,9 +415,14 @@ Instance.prototype.get = function get(name) {
 		notfound = false;
 	}
 	if (_.isObject(result)) {
-		// we need to return a cloned value otherwise if you mutate it and then attempt
-		// to update it, it won't think it's changed when you call set
-		result = _.cloneDeep(result);
+		if (result instanceof ObjectID) {
+			// ObjectID cannot be deeply copied via lodash correctly
+			result = new ObjectID(result);
+		} else {
+			// we need to return a cloned value otherwise if you mutate it and then attempt
+			// to update it, it won't think it's changed when you call set
+			result = _.cloneDeep(result);
+		}
 	}
 	if (!notfound) {
 		return result;

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "debug": "^2.1.1",
     "lodash": "^2.4.1",
     "mingo": "^0.3.1",
+    "mongodb": "^2.0.33",
     "pluralize": "^1.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
## Ticket Information
***JIRA Ticket***
https://jira.appcelerator.org/browse/API-864

***Description***
This PR is about to add mongo ObjectId support to arrow-orm, so that we can use type ObjectId in Arrow Model.

## Suggested Test Steps
\- Try with the following Model definition for appc.mongo:
```javascript
var Arrow = require('arrow');

var staff = Arrow.createModel('staff',{
    fields: {
        staff_id:{type:'mongo.oid', description:'Staff ID', required:true},
        name: {type:String, description:'Staff Name', required:true},
        created_at: {type:Date, description:'Created at', required:true}
    },
    connector: 'appc.mongo'
});

module.exports = staff;
```