### PR TITLE
[API-937] Connector Capabilities

### DIFF
--- a/lib/connector.js
+++ b/lib/connector.js
@@ -5,11 +5,14 @@ var util = require('util'),
 	events = require('events'),
 	_ = require('lodash'),
 	async = require('async'),
+	fs = require('fs'),
+	path = require('path'),
 	Instance = require('./instance'),
 	error = require('./error'),
 	Collection = require('./collection'),
 	ORMError = error.ORMError,
 	ConnectorPromise = require('./promise'),
+	Capabilities = require('./connector/capabilities'),
 	connectors = [],
 	ConnectorClass = new events.EventEmitter();
 
@@ -18,11 +21,11 @@ util.inherits(Connector, events.EventEmitter);
 module.exports = Connector;
 
 function Connector(impl, config) {
-	impl && _.merge(this,_.omit(impl,'connect'));
+	impl && _.merge(this, _.omit(impl, 'connect', 'disconnect'));
 	// setup our methods to delegate through...
-	var methods = impl && _.pick(impl,'create','save','update','upsert','findAndModify','findOne','findAll','find','query','delete','deleteAll','distinct','count');
+	var methods = impl && _.pick(impl, 'create', 'save', 'update', 'upsert', 'findAndModify', 'findOne', 'findAll', 'find', 'query', 'delete', 'deleteAll', 'distinct', 'count');
 	if (methods) {
-		Object.keys(methods).forEach(function connectorMethodIterator(method){
+		Object.keys(methods).forEach(function connectorMethodIterator(method) {
 			var fn = methods[method];
 			if (typeof fn === 'function') {
 				// if a function, delegate through our wrapper
@@ -35,23 +38,30 @@ function Connector(impl, config) {
 		}.bind(this));
 	}
 
+	// incoming constructor config should overwrite implementation
+	this.config = _.merge(impl && impl.config || {}, config);
+	if (!this.pkginfo && this.config && this.config.pkginfo) {
+		this.pkginfo = this.config.pkginfo;
+	}
+
 	// pull in these into the connector if we don't have them but we have them in our
 	// package
-	['description','version','name','author'].forEach(function(k){
+	['description', 'version', 'name', 'author'].forEach(function (k) {
 		if (!this[k] && this.pkginfo && (k in this.pkginfo)) {
 			this[k] = this.pkginfo[k];
 		}
 	}.bind(this));
 
-	// re-map connect for lifecycle
+	// re-map connect/disconnect for lifecycle
 	this._connect = impl && impl.connect;
+	this._disconnect = impl && impl.disconnect;
 	this.connected = false;
 
 	// incoming constructor config should overwrite implementation
 	this.config = _.merge(impl && impl.config || {}, config);
 
 	// if we provided a constructor in our impl, use it
-	if (this.constructor && this.constructor!==Connector && !this.constructor.super_) {
+	if (this.constructor && this.constructor !== Connector && !this.constructor.super_) {
 		this.constructor.call(this);
 		Connector.constructor.call(this);
 	}
@@ -60,29 +70,39 @@ function Connector(impl, config) {
 		throw new ORMError('connector is required to have a name');
 	}
 
-	if (connectors.indexOf(this)===-1) {
+	if (connectors.indexOf(this) === -1) {
 		connectors.push(this);
-		ConnectorClass.emit('register',this);
+		ConnectorClass.emit('register', this);
 	}
 }
 
 function wrapDelegate(connector, method, delegate) {
-	connector[method] = function methodWrapper(){
+	connector[method] = function methodWrapper() {
 		// check if we're connected and if so, go ahead and delegate
 		if (connector.connected) {
-			return delegate.apply(connector,arguments);
+			return delegate.apply(connector, arguments);
 		}
 		// we're not connected, call through to connect before continuing
 		else {
 			var callback = arguments[arguments.length - 1],
 				args = arguments;
-			connector.connect(function(err){
+			connector.connect(function (err) {
 				if (err) { return callback && callback(err); }
-				delegate.apply(connector,args);
+				delegate.apply(connector, args);
 			});
 		}
 	};
 }
+
+/**
+ * Defines various connector capabilities that you can enable to progressively be guided through connector development.
+ */
+Connector.Capabilities = Capabilities.Capabilities;
+
+/**
+ * Generates tests based on the defined capabilities of the connector, and based upon minimal configuration.
+ */
+Connector.generateTests = Capabilities.generateTests;
 
 /**
  * Returns the active Arrow Connectors.
@@ -99,7 +119,7 @@ Connector.getConnectors = function getConnectors() {
  * @param {String} name Event name
  * @param {Function} cb Callback function to execute.
  */
-Connector.on = function on(){
+Connector.on = function on() {
 	ConnectorClass.on.apply(ConnectorClass, arguments);
 };
 
@@ -109,7 +129,7 @@ Connector.on = function on(){
  * @param {String} name Event name
  * @param {Function} cb Callback function to remove.
  */
-Connector.removeListener = function removeListener(){
+Connector.removeListener = function removeListener() {
 	ConnectorClass.removeListener.apply(ConnectorClass, arguments);
 };
 
@@ -118,7 +138,7 @@ Connector.removeListener = function removeListener(){
  * @static
  * @param {String} [name] Event name.  If omitted, unbinds all event listeners.
  */
-Connector.removeAllListeners = function removeAllListeners(){
+Connector.removeAllListeners = function removeAllListeners() {
 	ConnectorClass.removeAllListeners.apply(ConnectorClass, arguments);
 };
 
@@ -137,15 +157,81 @@ Connector.prototype.createRequest = function createRequest(request, response) {
 /**
  * Creates a new connector.
  * @static
- * @param {Object} imp Implementation object. See the overview at the top of the page.
+ * @param {Object} impl Implementation object. See the overview at the top of the page.
  * @throws {Arrow.ORMError} Missing name parameter.
  */
 Connector.extend = function classExtend(impl) {
+	// Validate.
+	if (!impl) {
+		throw new TypeError('Missing require parameter "impl" to Connector.extend!');
+	}
+
+	// Provide some good defaults.
+	if (impl.filename) {
+		if (!impl.pkginfo) {
+			impl.pkginfo = _.pick(
+				require('pkginfo').read(impl).package,
+				'name', 'version', 'description', 'author', 'license', 'keywords', 'repository'
+			);
+		}
+
+		// Load up (well, delayed load up)
+		var modelsDir = path.resolve(path.join(impl.filename, '..', '..', 'models'));
+		if (!impl.models && fs.existsSync(modelsDir) && Connector.Arrow) {
+			impl.modelsDir = modelsDir;
+			// loadModelsForConnector will most likely defer loading the models until after getConnector finishes.
+			// So if impl.models is undefined after this, don't fret, it will be soon.
+			impl.models = Connector.Arrow.loadModelsForConnector(impl.name || impl.pkginfo.name, impl);
+		}
+
+		// Look for an example config file.
+		var exampleConfig = path.resolve(path.join(impl.filename, '..', '..', 'conf', 'example.config.js'));
+		if (!impl.defaultConfig && fs.existsSync(exampleConfig)) {
+			impl.defaultConfig = fs.readFileSync(exampleConfig, 'UTF-8');
+		}
+
+		// Allow convention based loading of modules from directories.
+		['lifecycle', 'metadata', 'schema', 'utility', 'methods'].forEach(function (dir) {
+			var subDir = path.resolve(path.join(impl.filename, '..', dir));
+			if (!fs.existsSync(subDir)) {
+				return;
+			}
+			fs.readdirSync(subDir)
+				.filter(function (f) {
+					return f.slice(-3) === '.js';
+				})
+				.forEach(function (f) {
+					try {
+						var module = require(path.join(subDir, f));
+						for (var key in module) {
+							if (module.hasOwnProperty(key) && _.isFunction(module[key]) && !impl[key]) {
+								impl[key] = module[key];
+							}
+						}
+					}
+					catch (err) {
+						console.error('Failed to load connector sub directory module; skipping it:');
+						console.error(err);
+					}
+				});
+		});
+	}
+	if (!impl.logger && Connector.Arrow) {
+		impl.logger = Connector.Arrow.getGlobal().logger;
+	}
+
+
+	// Validate our capabilities.
+	if (impl.capabilities) {
+		Capabilities.validateCapabilities(impl);
+	}
+
+	// Recursively apply extend, so connectors can extend connectors.
 	function ConnectorConstructor(config) {
 		return new Connector(impl, config);
 	}
 
-	ConnectorConstructor.extend = function(extendingImpl) {
+	ConnectorConstructor.extend = function (extendingImpl) {
 		return classExtend(_.merge(impl, extendingImpl));
 	};
 
@@ -154,11 +240,11 @@ Connector.extend = function classExtend(impl) {
 
 /**
  * Creates a new connector from this instance.
- * @param {Object} imp Implementation object. See the overview at the top of the page.
+ * @param {Object} impl Implementation object. See the overview at the top of the page.
  * @throws {Arrow.ORMError} Missing name parameter.
  */
 Connector.prototype.extend = function instanceExtend(impl) {
-	return Connector.extend(_.merge(this,impl));
+	return Connector.extend(_.merge(this, impl));
 };
 
 /**
@@ -204,8 +290,8 @@ Connector.prototype.getPrimaryKey = function getPrimaryKey(Model, record) {
  * @param {Function} callback Callback function passed an Error object (or null if successful).
  * The callback is invoked after each operation.
  */
-Connector.prototype.connect = function(callback) {
-	if (this.connected) {
+Connector.prototype.connect = function (callback) {
+	if (this.connected || this.config.enabled === false) {
 		return callback();
 	}
 	var tasks = [];
@@ -224,7 +310,7 @@ Connector.prototype.connect = function(callback) {
 		// no metadata, let's just make an empty one
 		tasks.push(function metadataTask(next) {
 			if (!this.metadata) {
-				this.metadata = { schema: undefined };
+				this.metadata = {schema: undefined};
 			}
 			next();
 		}.bind(this));
@@ -262,7 +348,12 @@ Connector.prototype.connect = function(callback) {
 	}
 	if (this._connect) {
 		tasks.push(function connectTask(next) {
-			this._connect(next);
+			try {
+				this._connect(next);
+			}
+			catch (err) {
+				next(err);
+			}
 		}.bind(this));
 	}
 	if (this.fetchSchema) {
@@ -270,9 +361,29 @@ Connector.prototype.connect = function(callback) {
 			this.fetchSchema(function fetchSchemaTaskCallback(err, schema) {
 				if (err) { return next(err); }
 				if (schema) {
-					this.metadata = _.merge(this.metadata || {}, { schema: schema });
+					this.metadata = _.merge(this.metadata || {}, {schema: schema});
+					this.schema = schema;
 				}
-				next();
+				if (!this._createdModelsFromSchema && this.createModelsFromSchema && (this.config.generateModelsFromSchema === undefined || this.config.generateModelsFromSchema)) {
+					var proceed = function () {
+						this._createdModelsFromSchema = true;
+						var server = Connector.Arrow && Connector.Arrow.getGlobal();
+						if (server) {
+							server.registerModelsForConnector(this, this.models);
+						}
+						next();
+					}.bind(this);
+					if (this.createModelsFromSchema.length > 0) {
+						this.createModelsFromSchema(proceed);
+					}
+					else {
+						this.createModelsFromSchema();
+						proceed();
+					}
+				}
+				else {
+					next();
+				}
 			}.bind(this));
 		}.bind(this));
 	}
@@ -288,7 +399,20 @@ Connector.prototype.connect = function(callback) {
  * @param {Function} callback Callback function to be called at the end of the operation.
  */
 Connector.prototype.disconnect = function disconnect(callback) {
-	callback();
+	if (!this.connected || this.config.enabled === false) {
+		return callback();
+	}
+	var tasks = [];
+	if (this._disconnect) {
+		tasks.push(function disconnectTask(next) {
+			this._disconnect(next);
+		}.bind(this));
+	}
+	async.series(tasks, function disconnectCallback(err) {
+		if (err) { return callback(err); }
+		this.connected = false;
+		callback();
+	}.bind(this));
 };
 
 /**
@@ -342,7 +466,7 @@ Connector.prototype.validateConfig = function validateConfig() {
  * @param {Arrow.Model} Model Model class to check.
  * @returns {String} Key name in the data source used as the primary key.
  */
-Connector.prototype.getPrimaryKeyColumnName = function(Model) {
+Connector.prototype.getPrimaryKeyColumnName = function (Model) {
 	return this.idAttribute || 'id';
 };
 
@@ -365,9 +489,9 @@ Connector.prototype.createMany = function createMany(Model, values, callback) {
  * @param {Function} callback Callback passed an Error object (or null if successful).
  */
 Connector.prototype.deleteMany = function deleteMany(Model, ids, callback) {
-	async.mapLimit(ids, 4, function(id, next){
-		Model.findOne(id, function(err, result){
-			if(err || !result){
+	async.mapLimit(ids, 4, function (id, next) {
+		Model.findOne(id, function (err, result) {
+			if (err || !result) {
 				return next();
 			}
 			Model.delete(id, next);
@@ -401,18 +525,18 @@ Connector.prototype.findAndModify = function findAndModify(Model, options, doc, 
 		callback = args;
 		args = {};
 	}
-	this.query(Model, (options.limit = 1, options), function(err, result){
+	this.query(Model, (options.limit = 1, options), function (err, result) {
 		if (err) {
 			return callback(err);
 		}
 		if (result && result.length) {
 			result[0].set(doc, false);
-			this.save(Model, result[0], function(err, record){
+			this.save(Model, result[0], function (err, record) {
 				callback(err, args.new ? record : result[0]);
 			});
 		}
 		else if (args.upsert) {
-			this.create(Model, doc, function(err, record){
+			this.create(Model, doc, function (err, record) {
 				callback(err, args.new ? record : {});
 			});
 		}
@@ -434,7 +558,7 @@ Connector.prototype.distinct = function distinct(Model, field, options, callback
 		callback = options;
 		options = {};
 	}
-	this.query(Model, options, function(err, results){
+	this.query(Model, options, function (err, results) {
 		if (err) {
 			return callback(err);
 		}
@@ -442,16 +566,16 @@ Connector.prototype.distinct = function distinct(Model, field, options, callback
 			var found = {},
 				array = [],
 				model = results.model,
-				// fields can be a comma-separated string of each field to use in distinct
-				keys = field.split(',').map(function(k){return k.trim();});
+			// fields can be a comma-separated string of each field to use in distinct
+				keys = field.split(',').map(function (k) {return k.trim();});
 
-			for (var c=0;c<results.length;c++) {
+			for (var c = 0; c < results.length; c++) {
 				var row = results[c],
 					key;
 
 				if (keys.length > 1) {
 					key = [];
-					keys.forEach(function(n){
+					keys.forEach(function (n) {
 						key.push(row.get(n));
 					});
 					key = key.join(',');
@@ -463,12 +587,12 @@ Connector.prototype.distinct = function distinct(Model, field, options, callback
 				if (key in found) {
 					continue;
 				}
-				found[key]=key;
+				found[key] = key;
 				array.push(row);
 			}
 
 			results = array;
-			callback(null, Array.isArray(results) ? results : new Collection(model,results));
+			callback(null, Array.isArray(results) ? results : new Collection(model, results));
 		}
 	});
 };
@@ -485,7 +609,7 @@ Connector.prototype.count = function count(Model, options, callback) {
 		callback = options;
 		options = {};
 	}
-	this.query(Model, options, function(err, results){
+	this.query(Model, options, function (err, results) {
 		if (err) {
 			return callback(err);
 		}
@@ -494,13 +618,13 @@ Connector.prototype.count = function count(Model, options, callback) {
 			if (options.distinct) {
 				var found = {};
 				count = 0;
-				for (var c=0;c<results.length;c++) {
+				for (var c = 0; c < results.length; c++) {
 					var row = results[c],
 						value = row.get(options.distinct);
 					if (value in found) {
 						continue;
 					}
-					found[value]=1;
+					found[value] = 1;
 					count++;
 				}
 			}
@@ -517,16 +641,16 @@ Connector.prototype.count = function count(Model, options, callback) {
  * @param {Function} callback Callback passed an Error object (or null if successful) and the new model.
  */
 Connector.prototype.upsert = function upsert(Model, id, document, callback) {
-	Model.findOne(id, function(err, record){
-		if(err){
+	Model.findOne(id, function (err, record) {
+		if (err) {
 			return callback(err);
 		}
-		if(!record && document){
+		if (!record && document) {
 			document.id = id;
 			Model.create(document, callback);
 		} else {
 			record.set(document);
-			record.save(function(err){
+			record.save(function (err) {
 				callback(err, record);
 			});
 		}

--- a/lib/connector/capabilities/generateTests.js
+++ b/lib/connector/capabilities/generateTests.js
@@ -1,0 +1,77 @@
+/* global it */
+var async = require('async'),
+	should = require('should'),
+	assert = require('assert'),
+	path = require('path'),
+	fs = require('fs'),
+	tests = mashModulesTogether(path.join(__dirname, 'tests'));
+
+module.exports = function (connector, testModule) {
+	return function () {
+		var dir = path.join(path.dirname(testModule.filename), 'capabilities');
+
+		if (!fs.existsSync(dir)) {
+			it('should have a test/capabilities dir', function () {
+				assert(false, 'test/capabilities does not exist');
+			});
+			return;
+		}
+
+		var suiteConfig = mashModulesTogether(dir);
+		Object.keys(suiteConfig).forEach(function (key) {
+			var testConfig = suiteConfig[key],
+				label = 'should ' + key;
+
+			if (!tests[key]) {
+				return;
+			}
+
+			if (testConfig.iterations !== undefined && testConfig.iterations > 1) {
+				label += ' ' + testConfig.iterations + ' times';
+			}
+
+			it(label, function (next) {
+				var count = testConfig.iterations || 1;
+				tests[key](connector, suiteConfig, testConfig, function oneFinished(err) {
+					if (err) {
+						next(err);
+					}
+					else if (--count > 0) {
+						tests[key](connector, suiteConfig, testConfig, oneFinished);
+					}
+					else {
+						next();
+					}
+				});
+			});
+		});
+	};
+};
+
+function mashModulesTogether(dir) {
+	var conglomerate = {},
+		filenames = fs
+			.readdirSync(dir)
+			.filter(function (filename) {
+				return filename[0] !== '.' && filename.slice(-3) === '.js';
+			});
+
+	for (var i = 0; i < filenames.length; i++) {
+
+		var filename = filenames[i],
+			currentConfig = require(path.join(dir, filename));
+
+		for (var key in currentConfig) {
+			if (currentConfig.hasOwnProperty(key)) {
+				conglomerate[key] = currentConfig[key];
+			}
+		}
+
+		if (currentConfig.only === true) {
+			return currentConfig;
+		}
+
+	}
+
+	return conglomerate;
+}

--- a/lib/connector/capabilities/index.js
+++ b/lib/connector/capabilities/index.js
@@ -1,0 +1,190 @@
+var fs = require('fs'),
+	path = require('path'),
+	chalk = require('chalk');
+
+/*
+ Public API.
+ */
+
+exports.validateCapabilities = validateCapabilities;
+/**
+ * Generates tests based upon the capabilities you have specified.
+ */
+exports.generateTests = require('./generateTests');
+
+/**
+ * Defines various connector specific capabilities; these are used by the validator to help developer's add new
+ * functionality to their connectors.
+ */
+var Capabilities = exports.Capabilities = {
+	/**
+	 * Specifies that the first time the connector is used, it will need to connect to a particular
+	 * data source before it can be used. For example, the MySQL connector connects to a MySQL server.
+	 */
+	ConnectsToADataSource: 'ConnectsToADataSource',
+	/**
+	 * Define validation on your validation files to ensure you get the data you need to run.
+	 * For example, a MongoDB connector could require a valid URL.
+	 */
+	ValidatesConfiguration: 'ValidatesConfiguration',
+	/**
+	 * Connectors can dynamically create models based upon loaded schema from their data sources.
+	 */
+	GeneratesModels: 'GeneratesModels',
+	/**
+	 * Connectors can contain static models, defined in their "models" directory.
+	 */
+	ContainsModels: 'ContainsModels',
+	/**
+	 * Enables a "create" method on this connector's models.
+	 */
+	CanCreate: 'CanCreate',
+	/**
+	 * Enables several methods such as findAll, findOne, or query on this connector's models.
+	 */
+	CanRetrieve: 'CanRetrieve',
+	/**
+	 * Enables an "update" method on this connector's models.
+	 */
+	CanUpdate: 'CanUpdate',
+	/**
+	 * Enables several methods such as delete and deleteAll on this connector's models.
+	 */
+	CanDelete: 'CanDelete',
+	/**
+	 * In addition to (or in place of) authenticating users in Arrow, the connector itself can validate a user
+	 * when a request is made to one of the connector's exposed methods. This is done through the user of headers.
+	 * For example, the Salesforce connector allows you to pass a Salesforce username, password, and token, or
+	 * an access token. Then all queries are made as this provided user, allowing the connector to leverage Salesforce's
+	 * access controls very easily.
+	 */
+	AuthenticatesThroughConnector: 'AuthenticatesThroughConnector'
+};
+
+/*
+ Implementation.
+ */
+
+var validations = {
+	ConnectsToADataSource: function (impl) {
+		return impl.connect && impl.disconnect;
+	},
+	ValidatesConfiguration: function (impl) {
+		return impl.fetchMetadata;
+	},
+	GeneratesModels: function (impl) {
+		return impl.fetchSchema && impl.createModelsFromSchema;
+	},
+	ContainsModels: function (impl) {
+		if (impl.models && Object.keys(impl.models).length > 0) {
+			return true;
+		}
+		// If models is empty, it's probably because we are waiting for the connector to finish loading first.
+		return impl.modelsDir && fs.readdirSync(impl.modelsDir)
+				.filter(function (f) {
+					return f.slice(-3) === '.js';
+				}).length > 0;
+	},
+	CanCreate: function (impl) {
+		return impl.create;
+	},
+	CanRetrieve: function (impl) {
+		return impl.findOne || impl.findAll || impl.query || impl.distinct;
+	},
+	CanUpdate: function (impl) {
+		return impl.save || impl.upsert || impl.findAndModify;
+	},
+	CanDelete: function (impl) {
+		return impl.delete || impl.deleteAll;
+	},
+	AuthenticatesThroughConnector: function (impl) {
+		return impl.loginRequired && impl.login;
+	}
+};
+
+function validateCapabilities(impl) {
+	var connectorDir = path.resolve(path.join(impl.filename, '..', '..')),
+		mightBeEmpty = Object.keys(impl).length <= 5 && impl.filename && impl.logger && impl.pkginfo && impl.defaultConfig && impl.capabilities !== undefined,
+		failed = false;
+
+	for (var i = 0; i < impl.capabilities.length; i++) {
+		var capability = impl.capabilities[i];
+		if (validations[capability] !== undefined) {
+			if (!validations[capability](impl)) {
+				failed = true;
+				console.log('');
+				console.log(chalk.green('The "' + chalk.underline(capability) + '" capability has been enabled, so we need to make a couple of changes:'));
+
+				var templateDir = path.join(__dirname, 'templates', capability);
+
+				crawlTemplates(connectorDir, templateDir);
+
+				logIfExists(path.join(templateDir, 'notes.txt'));
+			}
+			else {
+				mightBeEmpty = false;
+			}
+		}
+	}
+
+	if (failed) {
+		console.log('');
+		console.log(chalk.green('Please go take a look at the TODOs in these new files, then do an `' + chalk.bold('appc run') + '` or `' + chalk.bold('npm test') + '` to try out the new capabilities.'));
+		console.log('');
+
+		process.exit(1);
+	}
+
+	if (mightBeEmpty) {
+		console.log('');
+		console.log(chalk.red('This connector does not do much of anything at the moment.'));
+		console.log(chalk.red('Why don\'t you take a look at the "' + chalk.underline('capabilities') + '" array in:'));
+		console.log(chalk.red(path.join(connectorDir, 'lib', 'index.js')));
+		console.log('');
+	}
+}
+
+function crawlTemplates(connectorDir, templateDir, currentPath) {
+	var lookIn = currentPath ? path.join(templateDir, currentPath) : templateDir,
+		copyTo = currentPath ? path.join(connectorDir, currentPath) : connectorDir;
+
+	if (!fs.existsSync(lookIn)) {
+		return;
+	}
+	if (!fs.existsSync(copyTo)) {
+		fs.mkdirSync(copyTo);
+	}
+	var children = fs.readdirSync(lookIn);
+	for (var i = 0; i < children.length; i++) {
+		var child = children[i];
+		if (child[0] === '.') {
+			continue;
+		}
+		var templateFile = path.join(lookIn, child);
+		if (fs.statSync(templateFile).isDirectory()) {
+			crawlTemplates(connectorDir, templateDir, currentPath ? path.join(currentPath, child) : child);
+		}
+		else if (child.slice(-3) === '.js') {
+			var newFile = path.join(copyTo, child),
+				relNewFile = currentPath ? path.join(currentPath, child) : child;
+			if (!fs.existsSync(newFile)) {
+
+				var newContent = fs.readFileSync(templateFile, 'UTF-8');
+				fs.writeFileSync(newFile, newContent);
+
+				var todos = (newContent.match(/TODO/g) || []).length,
+					log = chalk.dim(' - ') + chalk.yellow('Created `' + chalk.underline(relNewFile) + '`');
+				if (todos) {
+					log += chalk.dim(' (contains ') + chalk.magenta(todos + ' TODOs') + chalk.dim(')');
+				}
+				console.log(log);
+			}
+		}
+	}
+}
+
+function logIfExists(ref) {
+	if (fs.existsSync(ref)) {
+		console.log(chalk.green(fs.readFileSync(ref, 'UTF-8')));
+	}
+}

--- a/lib/connector/capabilities/templates/AuthenticatesThroughConnector/lib/lifecycle/login.js
+++ b/lib/connector/capabilities/templates/AuthenticatesThroughConnector/lib/lifecycle/login.js
@@ -1,0 +1,40 @@
+// TODO: Reference the module to connect to your data store.
+var yourDataStore = require('your-data-store');
+
+/**
+ * login is called only if loginRequired calls next with the args (null, true). It looks at the current req, and
+ * either logs the user in (based on credentials provided in headers) or returns an error. It can return a session
+ * token via a res header so that future requests don't have to provide credentials.
+ */
+exports.login = function (req, res, next) {
+	var headers = req.headers || {},
+		username = headers.username,
+		password = headers.password;
+
+	// TODO: If we've gotten here, they haven't provided a token. If they don't provide credentials, then we can't login.
+	if (!headers.username || !headers.password) {
+		if (this.config.requireSessionLogin) {
+			return next('Authentication is required. Please pass these headers: username and password; or accessToken.');
+		}
+		else {
+			return next();
+		}
+	}
+
+	// TODO: Authenticate the user's credentials.
+	var self = this;
+	yourDataStore.authenticateTheUser(username, password, function (err, result) {
+		// TODO: If the authentication fails, then we'll show an error to the user. 
+		if (err) {
+			return next(err);
+		}
+
+		// TODO: Note on the controller (its state is specific to this req) who logged in.
+		self.loggedInUser = result;
+		// TODO: Optionally send back an access token that can be used instead of credentials in the future.
+		res.header('accessToken', result.accessToken);
+
+		// Let the controller carry on with the method that has been invoked:
+		return next();
+	});
+};

--- a/lib/connector/capabilities/templates/AuthenticatesThroughConnector/lib/lifecycle/loginRequired.js
+++ b/lib/connector/capabilities/templates/AuthenticatesThroughConnector/lib/lifecycle/loginRequired.js
@@ -1,0 +1,27 @@
+// TODO: Reference the module to connect to your data store.
+var yourDataStore = require('your-data-store');
+
+/**
+ * loginRequired checks to see if the current req for this connector requires the user to login.
+ */
+exports.loginRequired = function (req, next) {
+	var headers = req.headers || {};
+	// TODO: If the user doesn't provide a specific header, which you specify, such as "accesstoken"...
+	if (!headers.accesstoken) {
+		// ... then they need to login!
+		next(null, true);
+	}
+	else {
+		// TODO: Optionally make sure that the headers they provided are valid: 
+		yourDataStore.ensureAccessTokenIsGood(headers, function (err, isGood) {
+			// If we hit an error, or if it isn't good, then they need to login.
+			if (err || !isGood) {
+				return next(null, true);
+			}
+			// Otherwise, we're good to go!
+			else {
+				next(null, false);
+			}
+		});
+	}
+};

--- a/lib/connector/capabilities/templates/AuthenticatesThroughConnector/notes.txt
+++ b/lib/connector/capabilities/templates/AuthenticatesThroughConnector/notes.txt
@@ -1,0 +1,5 @@
+If you want to require authentication for all requests through this connector, please add the following to `conf/example.config.js` and `conf/local.js`:
+
+```
+	requireSessionLogin: true
+```

--- a/lib/connector/capabilities/templates/AuthenticatesThroughConnector/test/capabilities/login.js
+++ b/lib/connector/capabilities/templates/AuthenticatesThroughConnector/test/capabilities/login.js
@@ -1,0 +1,16 @@
+var config = require('../../conf/local').connectors;
+config = config[Object.keys(config)[0]];
+
+exports.login = {
+	// TODO: Customize all of these values according to your authentication.
+	authenticationHeaders: ['username', 'password'],
+	sessionHeaders: ['accesstoken'],
+	goodAuthentication: {
+		username: config.username,
+		password: config.password
+	},
+	badAuthentication: {
+		username: 'a-bad-username',
+		password: 'a-bad-password'
+	}
+};

--- a/lib/connector/capabilities/templates/CanCreate/lib/methods/create.js
+++ b/lib/connector/capabilities/templates/CanCreate/lib/methods/create.js
@@ -1,0 +1,32 @@
+// TODO: Reference the module to connect to your data store.
+var yourDataStore = require('your-data-store');
+
+/**
+ * Creates a new Model or Collection object.
+ * @param {Arrow.Model} Model The model class being updated.
+ * @param {Array<Object>/Object} [values] Attributes to set on the new model(s).
+ * @param {Function} callback Callback passed an Error object (or null if successful), and the new model or collection.
+ * @throws {Error}
+ */
+exports.create = function (Model, values, callback) {
+	var instance = Model.instance(values, false), // ... "instance" is an instance of the Model...
+		payload = instance.toPayload(); // ... and "payload" is the translated raw values, based on field names.
+
+	// TODO: Create the instance in your backing data store.
+	yourDataStore.create(payload, function (err, result) {
+		// If an error is hit:
+		if (err) {
+			return callback(err);
+		}
+
+		// If nothing was created by this request:
+		if (!result) {
+			return callback();
+		}
+
+		// TODO: Otherwise, if all went well:
+		var instance = Model.instance(result, true);
+		instance.setPrimaryKey(String(result._id)); // Note: the primary key can be a number, too.
+		callback(null, instance);
+	});
+};

--- a/lib/connector/capabilities/templates/CanCreate/test/capabilities/create.js
+++ b/lib/connector/capabilities/templates/CanCreate/test/capabilities/create.js
@@ -1,0 +1,14 @@
+var should = require('should');
+
+exports.create = {
+	iterations: 1, // To run this test multiple times (useful when you're caching results), increase this number.
+	insert: {
+		first_name: 'Nolan',
+		last_name: 'Wright'
+	},
+	check: function (result) {
+		// TODO: Check your results.
+		should(result.first_name).be.ok;
+		should(result.last_name).be.ok;
+	}
+};

--- a/lib/connector/capabilities/templates/CanDelete/lib/methods/delete.js
+++ b/lib/connector/capabilities/templates/CanDelete/lib/methods/delete.js
@@ -1,0 +1,25 @@
+// TODO: Reference the module to connect to your data store.
+var yourDataStore = require('your-data-store');
+
+/**
+ * Deletes the model instance.
+ * @param {Arrow.Model} Model The model class being updated.
+ * @param {Arrow.Instance} instance Model instance.
+ * @param {Function} callback Callback passed an Error object (or null if successful), and the deleted model.
+ */
+exports['delete'] = function (Model, instance, callback) {
+	// TODO: Delete the model, usually based on instance.getPrimaryKey().
+	yourDataStore.deleteByID(instance.getPrimaryKey(), function (err, result) {
+		if (err) {
+			return callback(err);
+		}
+
+		// TODO: If nothing was deleted by this request:
+		if (!result) {
+			return callback();
+		}
+
+		// TODO: Otherwise, if all went well:
+		callback(null, instance);
+	});
+};

--- a/lib/connector/capabilities/templates/CanDelete/lib/methods/deleteAll.js
+++ b/lib/connector/capabilities/templates/CanDelete/lib/methods/deleteAll.js
@@ -1,0 +1,24 @@
+// TODO: Reference the module to connect to your data store.
+var yourDataStore = require('your-data-store');
+
+/**
+ * Deletes all the data records.
+ * @param {Arrow.Model} Model The model class being updated.
+ * @param {Function} callback Callback passed an Error object (or null if successful), and the deleted models.
+ */
+exports.deleteAll = function (Model, callback) {
+	// TODO: Delete every result from the data store for this model.
+	yourDataStore.deleteAll(Model.name, function (err, count) {
+		if (err) {
+			return callback(err);
+		}
+
+		// TODO: If nothing was deleted by this request:
+		if (!count) {
+			return callback();
+		}
+
+		// TODO: Otherwise, if all went well:
+		callback(null, count);
+	});
+};

--- a/lib/connector/capabilities/templates/CanDelete/notes.txt
+++ b/lib/connector/capabilities/templates/CanDelete/notes.txt
@@ -1,0 +1,1 @@
+(Hint: If you only want to support some of these methods, feel free to delete the others.)

--- a/lib/connector/capabilities/templates/CanDelete/test/capabilities/delete.js
+++ b/lib/connector/capabilities/templates/CanDelete/test/capabilities/delete.js
@@ -1,0 +1,13 @@
+exports['delete'] = {
+	iterations: 1, // To run this test multiple times (useful when you're caching results), increase this number.
+	insert: [
+		{
+			first_name: 'Nolan',
+			last_name: 'Wright'
+		},
+		{
+			first_name: 'Jeff',
+			last_name: 'Haynie'
+		}
+	]
+};

--- a/lib/connector/capabilities/templates/CanRetrieve/lib/methods/distinct.js
+++ b/lib/connector/capabilities/templates/CanRetrieve/lib/methods/distinct.js
@@ -1,0 +1,21 @@
+// TODO: Reference the module to connect to your data store.
+var yourDataStore = require('your-data-store');
+
+/**
+ * Performs a query and returns a distinct result set based on the field(s).
+ * @param {Arrow.Model} Model Model class to check.
+ * @param {String} field Comma-separated list of fields.
+ * @param {ArrowQueryOptions} [options] Query options.
+ * @param {Function} callback Callback passed an Error object (or null if successful) and the distinct values array.
+ */
+exports.distinct = function distinct(Model, field, options, callback) {
+	// TODO: Find the distinct results for this Model from your data store.
+	yourDataStore.distinct(field, options.where, function (err, results) {
+		if (err) {
+			return callback(err);
+		}
+
+		// TODO: Return just the distinct values array.
+		callback(null, results);
+	});
+};

--- a/lib/connector/capabilities/templates/CanRetrieve/lib/methods/findAll.js
+++ b/lib/connector/capabilities/templates/CanRetrieve/lib/methods/findAll.js
@@ -1,0 +1,29 @@
+// TODO: Reference the module to connect to your data store.
+var yourDataStore = require('your-data-store'),
+	Arrow = require('arrow');
+
+/**
+ * Finds all model instances.  A maximum of 1000 models are returned.
+ * @param {Arrow.Model} Model The model class being updated.
+ * @param {Function} callback Callback passed an Error object (or null if successful) and the models.
+ */
+exports.findAll = function findAll(Model, callback) {
+	// TODO: Find all results for this Model from your data store. Arrow defaults to a limit of 1000 results.
+	yourDataStore.findAll(Model.name, function (err, results) {
+		if (err) {
+			return callback(err);
+		}
+
+		// TODO: Instantiate each result.
+		var array = [];
+		for (var c = 0; c < results.length; c++) {
+			var instance = Model.instance(results[c], true);
+			instance.setPrimaryKey(String(results[c].id));
+			array.push(instance);
+		}
+
+		// Turn the array of instances in to a collection, and return it.
+		callback(null, new Arrow.Collection(Model, array));
+
+	});
+};

--- a/lib/connector/capabilities/templates/CanRetrieve/lib/methods/findOne.js
+++ b/lib/connector/capabilities/templates/CanRetrieve/lib/methods/findOne.js
@@ -1,0 +1,27 @@
+// TODO: Reference the module to connect to your data store.
+var yourDataStore = require('your-data-store');
+
+/**
+ * Finds a model instance using the primary key.
+ * @param {Arrow.Model} Model The model class being updated.
+ * @param {String} id ID of the model to find.
+ * @param {Function} callback Callback passed an Error object (or null if successful) and the found model.
+ */
+exports.findOne = function (Model, id, callback) {
+	// TODO: Find the instance with the provided id.
+	yourDataStore.findOne(id, function (err, result) {
+		if (err) {
+			return callback(err);
+		}
+
+		// TODO: If nothing was found by this request:
+		if (!result) {
+			return callback();
+		}
+
+		// TODO: Otherwise, if all went well:
+		var instance = Model.instance(result, true);
+		instance.setPrimaryKey(String(result.id)); // Note: the primary key can be a number, too.
+		callback(null, instance);
+	});
+};

--- a/lib/connector/capabilities/templates/CanRetrieve/lib/methods/query.js
+++ b/lib/connector/capabilities/templates/CanRetrieve/lib/methods/query.js
@@ -1,0 +1,61 @@
+// TODO: Reference the module to connect to your data store.
+var yourDataStore = require('your-data-store'),
+	Arrow = require('arrow'),
+	_ = require('lodash');
+
+/**
+ * Queries for particular model records.
+ * @param {Arrow.Model} Model The model class being updated.
+ * @param {ArrowQueryOptions} options Query options.
+ * @param {Function} callback Callback passed an Error object (or null if successful) and the model records.
+ * @throws {Error} Failed to parse query options.
+ */
+exports.query = function (Model, options, callback) {
+	// TODO: Translate the Arrow style query fields below to line up with your data store.
+	var query = {
+		/**
+		 * A dictionary of the fields to include, such as { first_name: 1 }
+		 */
+		sel: Model.translateKeysForPayload(options.sel),
+		/**
+		 * A dictionary of the fields to exclude, such as { last_name: 0 }
+		 */
+		unsel: Model.translateKeysForPayload(options.unsel),
+		/**
+		 * A dictionary of fields to search by, ignoring keys that aren't specified in our model, and including "id",
+		 * such as { first_name: 'Daws%', last_name: 'Toth' }
+		 */
+		where: _.pick(Model.translateKeysForPayload(options.where), Model.payloadKeys().concat(['id'])),
+		/**
+		 * A dictionary of fields to order by, with a direction, such as { first_name: 1, last_name: -1 } where 1 is
+		 * ascending and -1 is descending.
+		 */
+		order: Model.translateKeysForPayload(options.order),
+		/**
+		 * A number indicating how far to skip through the results before returning them, such as 0 or 100, as well
+		 * as a limit on how many to return, such as 10 or 20. Alternatively, use options.page and options.per_page.
+		 * Arrow translates these for you.
+		 *
+		 * For example, a skip of 50 and a limit of 10 is equivalent to a page of 5 and a per_page of 10.
+		 */
+		skip: options.skip,
+		limit: options.limit
+	};
+
+	// TODO: Find the matching results for this Model from your data store. 
+	yourDataStore.query(query, function (err, results) {
+		if (err) {
+			return callback(err);
+		}
+
+		// TODO: Instantiate each result.
+		var array = [];
+		for (var c = 0; c < results.length; c++) {
+			var instance = Model.instance(results[c], true);
+			instance.setPrimaryKey(String(results[c].id));
+			array.push(instance);
+		}
+		// TODO: Turn the array of instances in to a collection.
+		callback(null, new Arrow.Collection(Model, array));
+	});
+};

--- a/lib/connector/capabilities/templates/CanRetrieve/notes.txt
+++ b/lib/connector/capabilities/templates/CanRetrieve/notes.txt
@@ -1,0 +1,1 @@
+(Hint: If you only want to support some of these methods, feel free to delete the others.)

--- a/lib/connector/capabilities/templates/CanRetrieve/test/capabilities/distinct.js
+++ b/lib/connector/capabilities/templates/CanRetrieve/test/capabilities/distinct.js
@@ -1,0 +1,20 @@
+var should = require('should');
+
+exports.distinct = {
+	// To run this test multiple times (useful when you're caching results), increase this number.
+	iterations: 1,
+	// TODO: If your connector doesn't support creating records, delete this "insert" object.
+	insert: [
+		{first_name: 'Rick', last_name: 'Blalock'},
+		{first_name: 'Jeff', last_name: 'Haynie'},
+		{first_name: 'Jeff', last_name: 'Smith'},
+		{first_name: 'Jeff', last_name: 'Hyatt'}
+	],
+	distinct: 'first_name',
+	check: function (results) {
+		// TODO: Check your results.
+		should(results.length).equal(2);
+		should(results).containEql('Rick');
+		should(results).containEql('Jeff');
+	}
+};

--- a/lib/connector/capabilities/templates/CanRetrieve/test/capabilities/findAll.js
+++ b/lib/connector/capabilities/templates/CanRetrieve/test/capabilities/findAll.js
@@ -1,0 +1,21 @@
+var should = require('should');
+
+exports.findAll = {
+	// To run this test multiple times (useful when you're caching results), increase this number.
+	iterations: 1,
+	// TODO: If your connector doesn't support creating records, delete this "insert" object.
+	insert: {
+		first_name: 'Nolan',
+		last_name: 'Wright'
+	},
+	check: function (results) {
+		should(results.length).be.above(0);
+		// TODO: Check your results.
+		for (var i = 0; i < results.length; i++) {
+			var result = results[i];
+			should(result.id).be.ok;
+			should(result.first_name).be.ok;
+			should(result.last_name).be.ok;
+		}
+	}
+};

--- a/lib/connector/capabilities/templates/CanRetrieve/test/capabilities/findOne.js
+++ b/lib/connector/capabilities/templates/CanRetrieve/test/capabilities/findOne.js
@@ -1,0 +1,17 @@
+var should = require('should');
+
+exports.findOne = {
+	// To run this test multiple times (useful when you're caching results), increase this number.
+	iterations: 1,
+	// TODO: If your connector doesn't support creating records, delete this "insert" object.
+	insert: {
+		first_name: 'Nolan',
+		last_name: 'Wright'
+	},
+	check: function (result) {
+		// TODO: Check your results.
+		should(result.id).be.ok;
+		should(result.first_name).equal('Nolan');
+		should(result.last_name).equal('Wright');
+	}
+};

--- a/lib/connector/capabilities/templates/CanRetrieve/test/capabilities/query.js
+++ b/lib/connector/capabilities/templates/CanRetrieve/test/capabilities/query.js
@@ -1,0 +1,28 @@
+var should = require('should');
+
+exports.query = {
+	// To run this test multiple times (useful when you're caching results), increase this number.
+	iterations: 1,
+	// TODO: If your connector doesn't support creating records, delete this "insert" object.
+	insert: [
+		{
+			first_name: 'Rick',
+			last_name: 'Blalock'
+		},
+		{
+			first_name: 'Nolan',
+			last_name: 'Wright'
+		}
+	],
+	query: {
+		where: {
+			first_name: 'Nolan'
+		}
+	},
+	check: function (results) {
+		should(results.length).be.above(0);
+		// TODO: Check your results.
+		should(results[0].first_name).be.ok;
+		should(results[0].last_name).be.ok;
+	}
+};

--- a/lib/connector/capabilities/templates/CanUpdate/lib/methods/findAndModify.js
+++ b/lib/connector/capabilities/templates/CanUpdate/lib/methods/findAndModify.js
@@ -1,0 +1,42 @@
+// TODO: Reference the module to connect to your data store.
+var yourDataStore = require('your-data-store'),
+	_ = require('lodash');
+
+/**
+ * Finds one model instance and modifies it.
+ * @param {Arrow.Model} Model
+ * @param {ArrowQueryOptions} options Query options.
+ * @param {Object} doc Attributes to modify.
+ * @param {Object} [args] Optional parameters.
+ * @param {Boolean} [args.new=false] Set to `true` to return the new model instead of the original model.
+ * @param {Boolean} [args.upsert=false] Set to `true` to allow the method to create a new model.
+ * @param {Function} callback Callback passed an Error object (or null if successful) and the modified model.
+ * @throws {Error} Failed to parse query options.
+ */
+exports.findAndModify = function findAndModify(Model, options, doc, args, callback) {
+	if (typeof args === "function") {
+		callback = args;
+		args = {};
+	}
+
+	// TODO: Translate the Arrow style query fields below to line up with your data store.
+	var where = _.pick(Model.translateKeysForPayload(options.where), Model.payloadKeys().concat(['id'])),
+		order = Model.translateKeysForPayload(options.order);
+
+	// TODO: Find and modify the instance in your backing data store.
+	yourDataStore.findAndModify(where, order, doc, args, function (err, result) {
+		if (err) {
+			return callback(err);
+		}
+
+		// TODO: If nothing was found by this request:
+		if (!result || Object.keys(result).length === 0) {
+			return callback(null, result);
+		}
+
+		// TODO: Otherwise, if all went well:
+		var instance = Model.instance(result, true);
+		instance.setPrimaryKey(String(result.id)); // Note: the primary key can be a number, too.
+		callback(null, instance);
+	});
+};

--- a/lib/connector/capabilities/templates/CanUpdate/lib/methods/save.js
+++ b/lib/connector/capabilities/templates/CanUpdate/lib/methods/save.js
@@ -1,0 +1,27 @@
+// TODO: Reference the module to connect to your data store.
+var yourDataStore = require('your-data-store');
+
+/**
+ * Updates a Model instance.
+ * @param {Arrow.Model} Model The model class being updated.
+ * @param {Arrow.Instance} instance Model instance to update.
+ * @param {Function} callback Callback passed an Error object (or null if successful) and the updated model.
+ */
+exports.save = function (Model, instance, callback) {
+	var payload = instance.toPayload(); // "payload" is the translated raw values, based on field names.
+
+	// TODO: Update the instance in your backing data store.
+	yourDataStore.update(instance.getPrimaryKey(), payload, function (err, result) {
+		if (err) {
+			return callback(err);
+		}
+
+		// TODO: If nothing was updated by this request:
+		if (!result) {
+			return callback();
+		}
+
+		// TODO: Otherwise, if all went well:
+		callback(null, instance);
+	});
+};

--- a/lib/connector/capabilities/templates/CanUpdate/lib/methods/upsert.js
+++ b/lib/connector/capabilities/templates/CanUpdate/lib/methods/upsert.js
@@ -1,0 +1,24 @@
+// TODO: Reference the module to connect to your data store.
+var yourDataStore = require('your-data-store');
+
+/**
+ * Updates a model or creates the model if it cannot be found.
+ * @param {Arrow.Model} Model The model class being updated.
+ * @param {String} id ID of the model to update.
+ * @param {Object} doc Model attributes to set.
+ * @param {Function} callback Callback passed an Error object (or null if successful) and the updated or new model.
+ */
+exports.upsert = function upsert(Model, id, doc, callback) {
+
+	// TODO: Upsert the instance in your backing data store.
+	yourDataStore.upsert(id, doc, function (err, result) {
+		if (err) {
+			return callback(err);
+		}
+
+		// TODO: Otherwise, if all went well:
+		var instance = Model.instance(result, true);
+		instance.setPrimaryKey(String(result.id)); // Note: the primary key can be a number, too.
+		callback(null, instance);
+	});
+};

--- a/lib/connector/capabilities/templates/CanUpdate/notes.txt
+++ b/lib/connector/capabilities/templates/CanUpdate/notes.txt
@@ -1,0 +1,1 @@
+(Hint: If you only want to support some of these methods, feel free to delete the others.)

--- a/lib/connector/capabilities/templates/CanUpdate/test/capabilities/findAndModify.js
+++ b/lib/connector/capabilities/templates/CanUpdate/test/capabilities/findAndModify.js
@@ -1,0 +1,13 @@
+var should = require('should');
+
+exports.findAndModify = {
+	insert: {
+		name: 'Dawson Toth'
+	},
+	query: {
+		name: 'Dawson Toth'
+	},
+	update: {
+		name: 'Dawson R Toth'
+	}
+};

--- a/lib/connector/capabilities/templates/CanUpdate/test/capabilities/save.js
+++ b/lib/connector/capabilities/templates/CanUpdate/test/capabilities/save.js
@@ -1,0 +1,18 @@
+var should = require('should');
+
+exports.save = {
+	iterations: 1, // To run this test multiple times (useful when you're caching results), increase this number.
+	insert: {
+		first_name: 'Dawson',
+		last_name: 'Toth'
+	},
+	update: {
+		last_name: 'Tooth'
+	},
+	check: function (result) {
+		// TODO: Check your results.
+		should(result.id).be.ok;
+		should(result.first_name).equal('Dawson');
+		should(result.last_name).equal('Tooth');
+	}
+};

--- a/lib/connector/capabilities/templates/CanUpdate/test/capabilities/upsert.js
+++ b/lib/connector/capabilities/templates/CanUpdate/test/capabilities/upsert.js
@@ -1,0 +1,7 @@
+var should = require('should');
+
+exports.upsert = {
+	insert: {
+		name: 'Pepper Toth'
+	}
+};

--- a/lib/connector/capabilities/templates/ConnectsToADataSource/lib/lifecycle/connect.js
+++ b/lib/connector/capabilities/templates/ConnectsToADataSource/lib/lifecycle/connect.js
@@ -1,0 +1,20 @@
+// TODO: Reference the module to connect to your data store.
+var yourDataStore = require('your-data-store');
+
+/**
+ * Connects to your data store; this connection can later be used by your connector's methods.
+ * @param next
+ */
+exports.connect = function (next) {
+	// Note: Our current context, aka "this", is a reference to your connector.
+	var self = this;
+	// TODO: Connect to your data source, and then call `next();`!
+	yourDataStore.connect(this.config, function (err, connection) {
+		if (err) {
+			return next(err);
+		}
+		// Note: now your methods can access this.connection!
+		self.connection = connection;
+		next();
+	});
+};

--- a/lib/connector/capabilities/templates/ConnectsToADataSource/lib/lifecycle/disconnect.js
+++ b/lib/connector/capabilities/templates/ConnectsToADataSource/lib/lifecycle/disconnect.js
@@ -1,0 +1,19 @@
+// TODO: Reference the module to connect to your data store.
+var yourDataStore = require('your-data-store');
+
+/**
+ * Disconnects from your data store.
+ * @param next
+ */
+exports.disconnect = function (next) {
+	// Note: Our current context, aka "this", is a reference to your connector.
+	var self = this;
+	// TODO: Disconnect from your data source, and then call `next();`!
+	yourDataStore.connect(function (err, connection) {
+		if (err) {
+			return next(err);
+		}
+		self.connection = null;
+		next();
+	});
+};

--- a/lib/connector/capabilities/templates/ConnectsToADataSource/test/capabilities/connect.js
+++ b/lib/connector/capabilities/templates/ConnectsToADataSource/test/capabilities/connect.js
@@ -1,0 +1,10 @@
+exports.connect = {
+	goodConfig: {
+		// TODO: Specify a good connection configuration for your connector.
+		url: 'mongodb://localhost/arrow'
+	},
+	badConfig: {
+		// TODO: Specify a bad connection configuration for your connector.
+		url: 'mongodb://255.255.255.255/arrow'
+	}
+};

--- a/lib/connector/capabilities/templates/ContainsModels/models/yourModel.js
+++ b/lib/connector/capabilities/templates/ContainsModels/models/yourModel.js
@@ -1,0 +1,11 @@
+var Arrow = require('arrow');
+
+// TODO: Rename "yourModel" (and this file) to whatever you want.
+module.exports = Arrow.Model.extend('yourModel', {
+	fields: {
+		// TODO: Customize these fields.
+		first_name: {type: String, required: true},
+		last_name: {type: String},
+		email: {type: String}
+	}
+});

--- a/lib/connector/capabilities/templates/GeneratesModels/lib/schema/createModelsFromSchema.js
+++ b/lib/connector/capabilities/templates/GeneratesModels/lib/schema/createModelsFromSchema.js
@@ -1,0 +1,36 @@
+var Arrow = require('arrow'),
+	_ = require('lodash');
+
+/**
+ * Creates models from your schema (see "fetchSchema" for more information on the schema).
+ */
+exports.createModelsFromSchema = function () {
+	var self = this,
+		models = {};
+
+	// TODO: Iterate through the models in your schema.
+	Object.keys(self.metadata.schema.objects).forEach(function (modelName) {
+		var object = self.metadata.schema.objects[modelName],
+			fields = {};
+		Object.keys(object).forEach(function (fieldName) {
+			var field = object[fieldName];
+			if (fieldName !== 'id') {
+				// TODO: Define the Arrow field definitions based on the schema.
+				fields[fieldName] = {
+					type: field.type || String,
+					required: field.required
+				};
+			}
+		});
+
+		models[self.name + '/' + modelName] = Arrow.Model.extend(self.name + '/' + modelName, {
+			name: self.name + '/' + modelName,
+			autogen: !!self.config.modelAutogen, // Controls if APIs are automatically created for this model.
+			fields: fields,
+			connector: self,
+			generated: true
+		});
+	});
+
+	self.models = _.defaults(self.models || {}, models);
+};

--- a/lib/connector/capabilities/templates/GeneratesModels/lib/schema/fetchSchema.js
+++ b/lib/connector/capabilities/templates/GeneratesModels/lib/schema/fetchSchema.js
@@ -1,0 +1,45 @@
+// TODO: Reference the module to connect to your data store.
+var yourDataStore = require('your-data-store');
+
+/**
+ * Fetches the schema for your connector.
+ *
+ * For example, your schema could look something like this:
+ * {
+ *     objects: {
+ *         person: {
+ *             first_name: {
+ *                 type: 'string',
+ *                 required: true
+ *             },
+ *             last_name: {
+ *                 type: 'string',
+ *                 required: false
+ *             },
+ *             age: {
+ *                 type: 'number',
+ *                 required: false
+ *             }
+ *         }
+ *     }
+ * }
+ *
+ * @param next
+ * @returns {*}
+ */
+exports.fetchSchema = function (next) {
+	var self = this;
+	// If we already have the schema, just return it.
+	if (this.metadata.schema) {
+		return next(null, this.metadata.schema);
+	}
+	yourDataStore.selectYourSchema(function (err, schema) {
+		// TODO: If you hit an error:
+		if (err) {
+			return next(err);
+		}
+
+		// TODO: Otherwise, parse your schema so that it's easy to look up information about your models.
+		return next(null, schema);
+	});
+};

--- a/lib/connector/capabilities/templates/GeneratesModels/notes.txt
+++ b/lib/connector/capabilities/templates/GeneratesModels/notes.txt
@@ -1,0 +1,6 @@
+Add the following to `conf/example.config.js` and `conf/local.js`:
+
+```
+	generateModelsFromSchema: true,
+	modelAutogen: true
+```

--- a/lib/connector/capabilities/templates/ValidatesConfiguration/lib/metadata/fetchMetadata.js
+++ b/lib/connector/capabilities/templates/ValidatesConfiguration/lib/metadata/fetchMetadata.js
@@ -1,0 +1,20 @@
+var Arrow = require('arrow');
+
+/**
+ * Fetches metadata describing your connector's proper configuration.
+ * @param next
+ */
+exports.fetchMetadata = function fetchMetadata(next) {
+	next(null, {
+		fields: [
+			// TODO: Add a field for each config property and customize the type, name, and description.
+			Arrow.Metadata.Text({
+				name: 'url',
+				description: 'connection url',
+				required: true
+			})
+			// TODO: After defining your fields, try an `appc run` to see it error!
+			// TODO: Then, go update your conf/local.js and conf/example.config.js so it passes validation.
+		]
+	});
+};

--- a/lib/connector/capabilities/tests/_util.js
+++ b/lib/connector/capabilities/tests/_util.js
@@ -1,0 +1,59 @@
+var assert = require('assert'),
+	_ = require('lodash');
+
+/**
+ * Handles the insert permutations from the test config.
+ */
+exports._handleInserts = function (Model, tasks, testConfig, required, checked) {
+	if (!testConfig.insert) {
+		if (required) {
+			throw new Error('This test needs to create an instance, but no "insert" object was defined in the test.');
+		}
+		else {
+			return;
+		}
+	}
+	tasks.push(function (next) {
+		Model.create(testConfig.insert, function (err, result) {
+			assert.ifError(err);
+			testConfig.inserted = result;
+			if (checked) {
+				if (_.isArray(testConfig.insert)) {
+					for (var i = 0; i < result.length; i++) {
+						checked && testConfig.check && testConfig.check(result[i]);
+					}
+				}
+				else {
+					testConfig.check && testConfig.check(result);
+				}
+			}
+			next();
+		});
+	});
+};
+
+/**
+ * Cleans up after the inserts task.
+ */
+exports._cleanupInserts = function (Model, tasks, testConfig, required) {
+	tasks.push(function (next) {
+		if (!testConfig.inserted) {
+			if (required) {
+				throw new Error('This test needed to create an instance, but nothing was inserted.');
+			}
+			else {
+				return next();
+			}
+		}
+		var toDelete = testConfig.inserted;
+		if (_.isArray(testConfig.inserted)) {
+			toDelete = toDelete.map(function (instance) {
+				return instance.getPrimaryKey();
+			});
+		}
+		Model.delete(toDelete, function (err) {
+			assert.ifError(err);
+			next();
+		});
+	});
+};

--- a/lib/connector/capabilities/tests/connect.js
+++ b/lib/connector/capabilities/tests/connect.js
@@ -1,0 +1,49 @@
+var assert = require('assert'),
+	async = require('async');
+
+exports.connect = function (connector, suiteConfig, testConfig, next) {
+	var tasks = [],
+		originalConfig = connector.config;
+
+	if (connector.connected) {
+		tasks.push(function (next) {
+			connector.disconnect(function (err) {
+				assert.ifError(err);
+				next();
+			});
+		});
+	}
+
+	if (testConfig.badConfig) {
+		tasks.push(function (next) {
+			connector.config = testConfig.badConfig;
+			connector.connect(function (err) {
+				assert(err, 'expected an error to be thrown when connecting with a bad config');
+				next();
+			});
+		});
+	}
+
+	if (testConfig.goodConfig) {
+		tasks.push(function (next) {
+			connector.config = testConfig.goodConfig;
+			connector.connect(function (err) {
+				assert.ifError(err);
+				connector.disconnect(function (err) {
+					assert.ifError(err);
+					connector.disconnect(next);
+				});
+			});
+		});
+	}
+
+	tasks.push(function (next) {
+		connector.config = originalConfig;
+		connector.connect(function (err) {
+			assert.ifError(err);
+			next();
+		});
+	});
+
+	async.series(tasks, next);
+};

--- a/lib/connector/capabilities/tests/create.js
+++ b/lib/connector/capabilities/tests/create.js
@@ -1,0 +1,14 @@
+var assert = require('assert'),
+	async = require('async');
+
+exports.create = function (connector, suiteConfig, testConfig, next) {
+	var Model = suiteConfig.model;
+	Model.connector = connector;
+
+	var tasks = [];
+
+	this._handleInserts(Model, tasks, testConfig, true, true);
+	this._cleanupInserts(Model, tasks, testConfig);
+
+	async.series(tasks, next);
+};

--- a/lib/connector/capabilities/tests/delete.js
+++ b/lib/connector/capabilities/tests/delete.js
@@ -1,0 +1,28 @@
+var assert = require('assert'),
+	async = require('async');
+
+exports['delete'] = function (connector, suiteConfig, testConfig, next) {
+	var Model = suiteConfig.model;
+	Model.connector = connector;
+
+	var tasks = [];
+
+	this._handleInserts(Model, tasks, testConfig, true);
+	this._cleanupInserts(Model, tasks, testConfig, true);
+
+	if ((testConfig.testDeleteAll === undefined || testConfig.testDeleteAll === true) && Model.deleteAll) {
+		this._handleInserts(Model, tasks, testConfig, true);
+		tasks.push(function (next) {
+			if (!testConfig.inserted) {
+				throw new Error('This test needed to create an instance, but nothing was inserted.');
+			}
+
+			Model.deleteAll(function (err) {
+				assert.ifError(err);
+				next();
+			});
+		});
+	}
+
+	async.series(tasks, next);
+};

--- a/lib/connector/capabilities/tests/distinct.js
+++ b/lib/connector/capabilities/tests/distinct.js
@@ -1,0 +1,23 @@
+var assert = require('assert'),
+	async = require('async');
+
+exports.distinct = function (connector, suiteConfig, testConfig, next) {
+	var Model = suiteConfig.model;
+	Model.connector = connector;
+
+	var tasks = [];
+
+	this._handleInserts(Model, tasks, testConfig);
+
+	tasks.push(function (next) {
+		Model.distinct(testConfig.distinct, testConfig.query || {}, function (err, results) {
+			assert.ifError(err);
+			testConfig.check && testConfig.check(results);
+			next();
+		});
+	});
+
+	this._cleanupInserts(Model, tasks, testConfig);
+
+	async.series(tasks, next);
+};

--- a/lib/connector/capabilities/tests/findAll.js
+++ b/lib/connector/capabilities/tests/findAll.js
@@ -1,0 +1,23 @@
+var assert = require('assert'),
+	async = require('async');
+
+exports.findAll = function (connector, suiteConfig, testConfig, next) {
+	var Model = suiteConfig.model;
+	Model.connector = connector;
+
+	var tasks = [];
+
+	this._handleInserts(Model, tasks, testConfig);
+
+	tasks.push(function (next) {
+		Model.findAll(function (err, results) {
+			assert.ifError(err);
+			testConfig.check && testConfig.check(results);
+			next();
+		});
+	});
+
+	this._cleanupInserts(Model, tasks, testConfig);
+
+	async.series(tasks, next);
+};

--- a/lib/connector/capabilities/tests/findAndModify.js
+++ b/lib/connector/capabilities/tests/findAndModify.js
@@ -1,0 +1,23 @@
+var assert = require('assert'),
+	async = require('async');
+
+exports.findAndModify = function (connector, suiteConfig, testConfig, next) {
+	var Model = suiteConfig.model;
+	Model.connector = connector;
+
+	var tasks = [];
+
+	this._handleInserts(Model, tasks, testConfig);
+
+	tasks.push(function (next) {
+		Model.findAndModify(testConfig.query, testConfig.update, function (err, result) {
+			assert.ifError(err);
+			testConfig.check && testConfig.check(result);
+			next();
+		});
+	});
+
+	this._cleanupInserts(Model, tasks, testConfig);
+
+	async.series(tasks, next);
+};

--- a/lib/connector/capabilities/tests/findOne.js
+++ b/lib/connector/capabilities/tests/findOne.js
@@ -1,0 +1,26 @@
+var assert = require('assert'),
+	async = require('async');
+
+exports.findOne = function (connector, suiteConfig, testConfig, next) {
+	var Model = suiteConfig.model;
+	Model.connector = connector;
+
+	var tasks = [];
+
+	this._handleInserts(Model, tasks, testConfig, true);
+
+	tasks.push(function (next) {
+		if (!testConfig.inserted) {
+			return next('Not inserted, so we cannot find it!');
+		}
+		Model.findOne(testConfig.inserted.getPrimaryKey(), function (err, result) {
+			assert.ifError(err);
+			testConfig.check && testConfig.check(result);
+			next();
+		});
+	});
+
+	this._cleanupInserts(Model, tasks, testConfig);
+
+	async.series(tasks, next);
+};

--- a/lib/connector/capabilities/tests/login.js
+++ b/lib/connector/capabilities/tests/login.js
@@ -1,0 +1,147 @@
+var assert = require('assert'),
+	async = require('async');
+
+exports.login = function (connector, suiteConfig, testConfig, next) {
+	var tasks = [],
+		origRequireSessionLogin = connector.config.requireSessionLogin;
+
+	// Simulate running in the browser.
+	connector.baseContext = connector;
+
+	/*
+	 Define some utility we will use throughout.
+	 */
+	var savedHeaders = {};
+
+	function saveHeader(name, value) {
+		savedHeaders[name.toLowerCase()] = value;
+	}
+
+	/*
+	 If headers are missing, or bad headers are provided, we should require login.
+	 */
+	tasks.push(function checkLoginRequiredWithoutHeaders(next) {
+		connector.loginRequired({}, assertLoginRequired(true, next));
+	});
+	tasks.push(function checkLoginRequiredWithEmptyHeaders(next) {
+		connector.loginRequired({headers: {}}, assertLoginRequired(true, next));
+	});
+
+	/*
+	 If requireSessionLogin:true and any of the auth headers are missing, login should fail.
+	 */
+	tasks.push(function checkLoginWithoutHeaders(next) {
+		connector.config.requireSessionLogin = true;
+		connector.login({}, {}, assertError(next));
+	});
+	tasks.push(function checkLoginWithEmptyHeaders(next) {
+		connector.config.requireSessionLogin = true;
+		connector.login({headers: {}}, {}, assertError(next));
+	});
+	tasks.push(function checkLoginWithEmptyHeaders(next) {
+		connector.config.requireSessionLogin = true;
+		var headers = {};
+		// Provide all but one of the headers.
+		for (var i = 0; i < -1 + testConfig.authenticationHeaders.length; i++) {
+			var header = testConfig.authenticationHeaders[i];
+			headers[header] = 'a-value';
+		}
+		connector.login({headers: headers}, {}, assertError(next));
+	});
+
+	/*
+	 If requireSessionLogin:false and any of the auth headers are missing, login should carry on.
+	 */
+	tasks.push(function checkLoginWithoutHeaders(next) {
+		connector.config.requireSessionLogin = false;
+		connector.login({}, {}, assertSuccess(next));
+	});
+	tasks.push(function checkLoginWithEmptyHeaders(next) {
+		connector.config.requireSessionLogin = false;
+		connector.login({headers: {}}, {}, assertSuccess(next));
+	});
+	tasks.push(function checkLoginWithEmptyHeaders(next) {
+		connector.config.requireSessionLogin = false;
+		var headers = {};
+		// Provide all but one of the headers.
+		for (var i = 0; i < -1 + testConfig.authenticationHeaders.length; i++) {
+			var header = testConfig.authenticationHeaders[i];
+			headers[header] = 'a-value';
+		}
+		connector.login({headers: headers}, {}, assertSuccess(next));
+	});
+
+	/*
+	 If bad auth headers are provided, login should error.
+	 */
+	tasks.push(function checkLoginWithBadAuthHeaders1(next) {
+		connector.config.requireSessionLogin = true;
+		connector.login({headers: testConfig.badAuthentication}, {}, assertError(next));
+	});
+	tasks.push(function checkLoginWithBadAuthHeaders2(next) {
+		connector.config.requireSessionLogin = false;
+		connector.login({headers: testConfig.badAuthentication}, {}, assertError(next));
+	});
+
+	/*
+	 If good auth headers are provided, login should succeed.
+	 */
+	tasks.push(function checkLoginWithGoodAuthHeaders1(next) {
+		connector.config.requireSessionLogin = true;
+		connector.login({headers: testConfig.goodAuthentication}, fakeResponse(saveHeader), assertSuccess(next));
+	});
+	tasks.push(function checkLoginWithGoodAuthHeaders2(next) {
+		connector.config.requireSessionLogin = false;
+		connector.login({headers: testConfig.goodAuthentication}, fakeResponse(saveHeader), assertSuccess(next));
+	});
+
+	/*
+	 If good tokens are provided, we shouldn't require login.
+	 */
+	tasks.push(function checkLoginRequiredWithAccessTokens1(next) {
+		connector.config.requireSessionLogin = true;
+		connector.loginRequired({headers: savedHeaders}, assertLoginRequired(false, next));
+	});
+	tasks.push(function checkLoginRequiredWithAccessTokens2(next) {
+		connector.config.requireSessionLogin = false;
+		connector.loginRequired({headers: savedHeaders}, assertLoginRequired(false, next));
+	});
+
+	/*
+	 Put things back the way we found them.
+	 */
+	tasks.push(function restoreOriginalSettings(next) {
+		connector.config.requireSessionLogin = origRequireSessionLogin;
+		next();
+	});
+
+	async.series(tasks, next);
+};
+
+function assertLoginRequired(expected, next) {
+	return function (err, required) {
+		assert.ifError(err);
+		assert.equal(required, expected, 'loginRequired unexpected response');
+		next();
+	};
+}
+
+function assertError(next) {
+	return function (err) {
+		assert(err, 'expected an error to be returned');
+		next();
+	};
+}
+
+function assertSuccess(next) {
+	return function (err) {
+		assert.ifError(err);
+		next();
+	};
+}
+
+function fakeResponse(saveHeader) {
+	return {
+		header: saveHeader
+	};
+}

--- a/lib/connector/capabilities/tests/query.js
+++ b/lib/connector/capabilities/tests/query.js
@@ -1,0 +1,28 @@
+var _ = require('lodash'),
+	assert = require('assert'),
+	async = require('async');
+
+exports.query = function (connector, suiteConfig, testConfig, next) {
+	var Model = suiteConfig.model;
+	Model.connector = connector;
+
+	var tasks = [];
+
+	this._handleInserts(Model, tasks, testConfig);
+
+	var queries = _.isArray(testConfig.query) ? testConfig.query : [testConfig.query];
+	for (var i = 0; i < queries.length; i++) {
+		var query = queries[i];
+		tasks.push(function (next) {
+			Model.query(this.query, function (err, results) {
+				assert.ifError(err);
+				testConfig.check && testConfig.check(results);
+				next();
+			});
+		}.bind({query: query}));
+	}
+
+	this._cleanupInserts(Model, tasks, testConfig);
+
+	async.series(tasks, next);
+};

--- a/lib/connector/capabilities/tests/save.js
+++ b/lib/connector/capabilities/tests/save.js
@@ -1,0 +1,29 @@
+var assert = require('assert'),
+	async = require('async');
+
+exports.save = function (connector, suiteConfig, testConfig, next) {
+	var Model = suiteConfig.model;
+	Model.connector = connector;
+
+	var tasks = [];
+
+	this._handleInserts(Model, tasks, testConfig, true);
+
+	tasks.push(function (next) {
+		var updates = testConfig.update;
+		for (var key in updates) {
+			if (updates.hasOwnProperty(key)) {
+				testConfig.inserted[key] = updates[key];
+			}
+		}
+		Model.save(testConfig.inserted, function (err, result) {
+			assert.ifError(err);
+			testConfig.check && testConfig.check(result);
+			next();
+		});
+	});
+
+	this._cleanupInserts(Model, tasks, testConfig);
+
+	async.series(tasks, next);
+};

--- a/lib/connector/capabilities/tests/upsert.js
+++ b/lib/connector/capabilities/tests/upsert.js
@@ -1,0 +1,23 @@
+var assert = require('assert'),
+	async = require('async');
+
+exports.upsert = function (connector, suiteConfig, testConfig, next) {
+	var Model = suiteConfig.model;
+	Model.connector = connector;
+
+	var tasks = [];
+
+	this._handleInserts(Model, tasks, testConfig);
+
+	tasks.push(function (next) {
+		Model.upsert(testConfig.inserted.getPrimaryKey(), testConfig.inserted, function (err, result) {
+			assert.ifError(err);
+			testConfig.check && testConfig.check(result);
+			next();
+		});
+	});
+
+	this._cleanupInserts(Model, tasks, testConfig);
+
+	async.series(tasks, next);
+};

--- a/lib/model.js
+++ b/lib/model.js
@@ -502,6 +502,7 @@ Model.prototype.updateAPI = function updateAPI() {
 		afterEvent: this.afterUpdateEvent || this.afterEvent,
 		eventTransformer: this.updateEventTransformer || this.eventTransformer,
 		parameters: parameters,
+		dependsOnAll: ['save'],
 		action: function updateAction(req, resp, next) {
 			req.model.fetch(req.params.id, resp.createCallback(null, function putSuccessCallback(model, cb) {
 				try {
@@ -674,6 +675,7 @@ Model.prototype.distinctAPI = function distinctAPI() {
 		method: 'GET',
 		path: './distinct',
 		actionGroup: 'read',
+		dependsOnAll: ['query'],
 		description: this.description || 'Find distinct ' + this.plural,
 		beforeEvent: this.beforeDistinctEvent || this.beforeEvent,
 		afterEvent: this.afterDistinctEvent || this.afterEvent,
@@ -822,6 +824,7 @@ Model.prototype.findAndModifyAPI = function findAndModifyAPI() {
 		path: './findAndModify',
 		actionGroup: 'read',
 		method: 'PUT',
+		dependsOnAll: ['query', 'create', 'save'],
 		beforeEvent: this.beforeFindAndModifyEvent || this.beforeEvent,
 		afterEvent: this.afterFindAndModifyEvent || this.afterEvent,
 		eventTransformer: this.findAndModifyEventTransformer || this.eventTransformer,
@@ -871,6 +874,7 @@ Model.prototype.findAllAPI = function findAllAPI() {
 		description: this.description || 'Find all ' + this.plural,
 		actionGroup: 'read',
 		method: 'GET',
+		dependsOnAny: ['findAll', 'query'],
 		action: function findAllAction(req, resp, next) {
 			try {
 				resp.stream(req.model.findAll, next);
@@ -909,6 +913,7 @@ Model.prototype.countAPI = function countAPI() {
 	result.uiSort = 7;
 	result.path = './count';
 	result.description = this.description || 'Count ' + this.plural;
+	result.dependsOnAny = ['query'];
 	result.beforeEvent = this.beforeCountEvent || this.beforeEvent;
 	result.afterEvent = this.afterCountEvent || this.afterEvent;
 	result.eventTransformer = this.countEventTransformer || this.eventTransformer;
@@ -952,6 +957,7 @@ Model.prototype.upsertAPI = function upsertAPI() {
 	result.actionGroup = 'create';
 	result.description = this.description || 'Create or update a ' + this.singular;
 	result.parameters.id = { description: 'The ' + this.singular + ' ID', type: 'body', optional: false, required: true };
+	result.dependsOnAll = ['save', 'create'];
 	result.beforeEvent = this.beforeUpsertEvent || this.beforeEvent;
 	result.afterEvent = this.afterUpsertEvent || this.afterEvent;
 	result.eventTransformer = this.upsertEventTransformer || this.eventTransformer;
@@ -1469,6 +1475,6 @@ function prepareQueryOptions(ctx, options) {
 	if (ctx.getConnector().translateWhereRegex && options.where !== undefined) {
 		translateQueryRegex(options.where);
 	}
-
+	
 	return options;
 }

--- a/package.json
+++ b/package.json
@@ -14,10 +14,11 @@
   "author": "Jeff Haynie",
   "dependencies": {
     "async": "^0.9.0",
-    "chalk": "^0.5.1",
+    "chalk": "^1.1.0",
     "debug": "^2.1.1",
     "lodash": "^2.4.1",
     "mingo": "^0.3.1",
+    "pkginfo": "^0.3.0",
     "pluralize": "^1.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This will only be really useful with the latest changes to Arrow.

In order to lighten the load on connector developers, we can infer a lot of the annoying boiler plate properties. We can also make the lifecycle more intuitive.

Added the concept of "capabilities", which initially will just do some basic runtime checks on the connector implementation to see if they're being met. If they aren't, then we can log some helpful guidance for the connector dev to use. This can result in a quick, step-by-step process for building connectors.

I also introduced a convention for structuring connectors so that they don't by-default build up a single lib/index.js file.

https://jira.appcelerator.org/browse/API-937