### PR TITLE
[API-1199] Out-of-the-box findOne API does not exist any more

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -846,7 +846,7 @@ Model.prototype.distinct = function distinct(field, options, callback) {
  * Documents the findByID method for API usage.
  * @return {Object}
  */
-Model.prototype.findByIDAPI = function findByIDAPI() {
+Model.prototype.findByIDAPI = Model.prototype.findOneAPI = function findByIDAPI() {
 	return {
 		generated: true,
 		uiSort: 4,


### PR DESCRIPTION
https://jira.appcelerator.org/browse/API-1199
Alias `findByID` so existing connectors that implement `findOne` should still be working.